### PR TITLE
Add identifier with string

### DIFF
--- a/src/main/java/com/hprc/Main.java
+++ b/src/main/java/com/hprc/Main.java
@@ -6,8 +6,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
 
 public class Main {
     private static final Logger logger = LoggerFactory.getLogger("Groundstation");
@@ -28,18 +26,18 @@ public class Main {
         serial.setBaudRate(115200);
         serial.enableLogging();
 
-        serial.addIdentifier(new ArrayList<>(Arrays.asList(65,67,88)), "AccelX", DataTypes.SIGNED_INT);
-        serial.addIdentifier(new ArrayList<>(Arrays.asList(65,67,89)), "AccelY", DataTypes.SIGNED_INT);
-        serial.addIdentifier(new ArrayList<>(Arrays.asList(65,67,90)), "AccelZ", DataTypes.SIGNED_INT);
-        serial.addIdentifier(new ArrayList<>(Arrays.asList(71,89,88)), "GyroX", DataTypes.SIGNED_INT);
-        serial.addIdentifier(new ArrayList<>(Arrays.asList(71,89,89)), "GyroY", DataTypes.SIGNED_INT);
-        serial.addIdentifier(new ArrayList<>(Arrays.asList(71,89,90)), "GyroZ", DataTypes.SIGNED_INT);
-        serial.addIdentifier(new ArrayList<>(Arrays.asList(65,76,84)), "Altitude", DataTypes.FLOAT);
-        serial.addIdentifier(new ArrayList<>(Arrays.asList(83,84,84)), "State", DataTypes.SIGNED_INT);
-        serial.addIdentifier(new ArrayList<>(Arrays.asList(84,83,80)), "Timestamp", DataTypes.SIGNED_INT);
-        serial.addIdentifier(new ArrayList<>(Arrays.asList(84,77,80)), "Temperature", DataTypes.FLOAT);
-        serial.addIdentifier(new ArrayList<>(Arrays.asList(86,79,76)), "Voltage", DataTypes.FLOAT);
-        serial.addIdentifier(new ArrayList<>(Arrays.asList(69,78,68,66)), "EndByte", DataTypes.END_BYTES);
+        serial.addIdentifier("ACX", "AccelX", DataTypes.SIGNED_INT);
+        serial.addIdentifier("ACY", "AccelY", DataTypes.SIGNED_INT);
+        serial.addIdentifier("ACZ", "AccelZ", DataTypes.SIGNED_INT);
+        serial.addIdentifier("GYX", "GyroX", DataTypes.SIGNED_INT);
+        serial.addIdentifier("GYY", "GyroY", DataTypes.SIGNED_INT);
+        serial.addIdentifier("GYZ", "GyroZ", DataTypes.SIGNED_INT);
+        serial.addIdentifier("ALT", "Altitude", DataTypes.FLOAT);
+        serial.addIdentifier("STT", "State", DataTypes.SIGNED_INT);
+        serial.addIdentifier("TSP", "Timestamp", DataTypes.SIGNED_INT);
+        serial.addIdentifier("TMP", "Temperature", DataTypes.FLOAT);
+        serial.addIdentifier("VOL", "Voltage", DataTypes.FLOAT);
+        serial.addIdentifier("ENDB", "EndByte", DataTypes.END_BYTES);
 
         serial.startStream();
 

--- a/src/main/java/com/hprc/serial/SerialManager.java
+++ b/src/main/java/com/hprc/serial/SerialManager.java
@@ -9,10 +9,12 @@ import org.slf4j.LoggerFactory;
 
 import com.hprc.Conversion;
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @SuppressWarnings({"unused", "rawtypes", "SuspiciousMethodCalls"})
 public class SerialManager implements SerialPortEventListener {
@@ -82,6 +84,25 @@ public class SerialManager implements SerialPortEventListener {
      */
     public void addIdentifier(ArrayList<Integer> identifierBytes, String name, DataTypes datatype) {
         Identifier identifier = new Identifier(identifierBytes,name,datatype);
+        identifiers.add(identifier);
+        telemetry.put(name, 0);
+    }
+
+    private ArrayList<Integer> intArrToArrList(int[] ints) {
+        return IntStream.of(ints)
+                .boxed()
+                .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    public void addIdentifier(String identifierStr, String name, DataTypes datatype) {
+        byte[] ascii = identifierStr.getBytes(StandardCharsets.US_ASCII);
+        int[] ints = new int[3];
+
+        for (int i = 0; i < ascii.length; i++) {
+            ints[i] = ascii[i];
+        }
+
+        Identifier identifier = new Identifier(intArrToArrList(ints),name,datatype);
         identifiers.add(identifier);
         telemetry.put(name, 0);
     }


### PR DESCRIPTION
Added overload function for  ```serial.addIdentifier```; instead of having to type in the ascii bits (i.e. ```new ArrayList<>(Arrays.asList(65,67,88))```), you can enter a String (i.e. ```"ACX"```). Easier to read for people who don't want to do the ascii conversions mentally. Also changed the ```serial.addIdentifier``` calls in ```Main.java``` from sending the ascii bits to sending a String.